### PR TITLE
Adds VILA vLM

### DIFF
--- a/src/omOS_vlm/main.py
+++ b/src/omOS_vlm/main.py
@@ -13,6 +13,7 @@ from .processor import ConnectionProcessor
 
 logger = logging.getLogger(__name__)
 
+
 class Application:
     """
     Main application class for managing VLM processing and video streaming.
@@ -38,6 +39,7 @@ class Application:
         - log_level : str
             Logging level (default: "INFO")
     """
+
     def __init__(self, args: argparse.Namespace):
         self.args = args
         self.ws_server: ws.Server = None
@@ -58,7 +60,9 @@ class Application:
         # Set logging level in the lower level modules
         logging.basicConfig(level=getattr(logging, self.args.log_level.upper()))
         for name in logging.root.manager.loggerDict:
-            logging.getLogger(name).setLevel(getattr(logging, self.args.log_level.upper()))
+            logging.getLogger(name).setLevel(
+                getattr(logging, self.args.log_level.upper())
+            )
 
     @staticmethod
     def parse_arguments() -> argparse.Namespace:
@@ -71,13 +75,31 @@ class Application:
             Parsed command-line arguments
         """
         parser = ArgParser(extras=ArgParser.Defaults)
-        parser.add_argument("--ws-host", type=str, default="localhost", help="WebSocket server host")
+        parser.add_argument(
+            "--ws-host", type=str, default="localhost", help="WebSocket server host"
+        )
         parser.add_argument("--ws-port", type=int, help="WebSocket server port")
-        parser.add_argument("--rtp-url", type=str, help="RTP URL for compressed video stream")
-        parser.add_argument("--server-mode", default=False, action="store_true", help="Run in server mode")
-        parser.add_argument("--remote-url", type=str, help="Remote webSocket URL server for video stream input")
-        parser.add_argument("--log-level", type=str, default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="Set the logging level")
-
+        parser.add_argument(
+            "--rtp-url", type=str, help="RTP URL for compressed video stream"
+        )
+        parser.add_argument(
+            "--server-mode",
+            default=False,
+            action="store_true",
+            help="Run in server mode",
+        )
+        parser.add_argument(
+            "--remote-url",
+            type=str,
+            help="Remote webSocket URL server for video stream input",
+        )
+        parser.add_argument(
+            "--log-level",
+            type=str,
+            default="INFO",
+            choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+            help="Set the logging level",
+        )
         return parser.parse_args()
 
     # Demo for video streaming and retrieving VLM results
@@ -105,20 +127,25 @@ class Application:
         self.ws_server = ws.Server(host=self.args.ws_host, port=self.args.ws_port)
 
         if self.args.server_mode:
-            self.connection_processor = ConnectionProcessor(self.args, VLMProcessor, VideoStreamInput)
+            self.connection_processor = ConnectionProcessor(
+                self.args, VLMProcessor, VideoStreamInput
+            )
             self.connection_processor.set_server(self.ws_server)
         else:
-            self.vlm_processor = VLMProcessor(self.args, self.ws_server.handle_global_response)
+            self.vlm_processor = VLMProcessor(
+                self.args, self.ws_server.handle_global_response
+            )
             self.video_device_processor = VideoDeviceInput()
-            self.video_source, self.video_output = self.video_device_processor.setup_video_devices(
-                self.args,
-                self.vlm_processor.on_video
+            self.video_source, self.video_output = (
+                self.video_device_processor.setup_video_devices(
+                    self.args, self.vlm_processor.on_video
+                )
             )
 
             vlm_thread = threading.Thread(
                 target=self.vlm_processor.process_frames,
                 args=(self.video_output, self.video_source),
-                daemon=True
+                daemon=True,
             )
             vlm_thread.start()
 
@@ -178,6 +205,7 @@ class Application:
         if self.video_output:
             self.video_output.stop()
 
+
 def main():
     """
     Main entry point for the application.
@@ -187,6 +215,7 @@ def main():
     args = Application.parse_arguments()
     app = Application(args)
     app.start()
+
 
 if __name__ == "__main__":
     main()

--- a/src/omOS_vlm/video/video_stream.py
+++ b/src/omOS_vlm/video/video_stream.py
@@ -60,19 +60,6 @@ class VideoStream:
             If video streaming encounters an error
         """
 
-        if platform.system() == "Darwin":
-            # For macOS, try to get camera permissions first
-            try:
-                # This will trigger the permission dialog if not already granted
-                test_cap = cv2.VideoCapture(0)
-                if not test_cap.isOpened():
-                    logger.error("Camera permission denied or camera not available")
-                    return
-                test_cap.release()
-            except Exception as e:
-                logger.error(f"Error accessing camera on macOS: {e}")
-                return
-
         devices = enumerate_video_devices()
         if platform.system() == "Darwin":
             camindex = 0 if devices else 0

--- a/src/omOS_vlm/video/video_stream.py
+++ b/src/omOS_vlm/video/video_stream.py
@@ -9,7 +9,8 @@ from typing import Optional, Callable
 
 logger = logging.getLogger(__name__)
 
-class VideoStream():
+
+class VideoStream:
     """
     Manages video capture and streaming from a camera device.
 
@@ -23,8 +24,16 @@ class VideoStream():
         Callback function to handle processed frame data.
         Function receives base64 encoded frame data.
         By default None
+    fps : Optional[int], optional
+        Frames per second to capture.
+        By default 30
     """
-    def __init__(self, frame_callback: Optional[Callable[[str], None]] = None):
+
+    def __init__(
+        self,
+        frame_callback: Optional[Callable[[str], None]] = None,
+        fps: Optional[int] = 30,
+    ):
         self._video_thread: Optional[threading.Thread] = None
 
         # Callback for video frame data
@@ -34,6 +43,9 @@ class VideoStream():
         self._cap = None
 
         self.running: bool = True
+
+        self.fps = fps
+        self.frame_delay = 1.0 / fps  # Calculate delay between frames
 
     def on_video(self):
         """
@@ -48,11 +60,24 @@ class VideoStream():
             If video streaming encounters an error
         """
 
+        if platform.system() == "Darwin":
+            # For macOS, try to get camera permissions first
+            try:
+                # This will trigger the permission dialog if not already granted
+                test_cap = cv2.VideoCapture(0)
+                if not test_cap.isOpened():
+                    logger.error("Camera permission denied or camera not available")
+                    return
+                test_cap.release()
+            except Exception as e:
+                logger.error(f"Error accessing camera on macOS: {e}")
+                return
+
         devices = enumerate_video_devices()
-        if platform.system() == 'Darwin':
+        if platform.system() == "Darwin":
             camindex = 0 if devices else 0
         else:
-            camindex = '/dev/video' + str(devices[0][0]) if devices else '/dev/video0'
+            camindex = "/dev/video" + str(devices[0][0]) if devices else "/dev/video0"
         logger.info(f"Using camera: {camindex}")
 
         self._cap = cv2.VideoCapture(camindex)
@@ -69,13 +94,15 @@ class VideoStream():
                     continue
 
                 # Convert frame to base64
-                _, buffer = cv2.imencode('.jpg', frame, [cv2.IMWRITE_JPEG_QUALITY, 80])
-                frame_data = base64.b64encode(buffer).decode('utf-8')
+                _, buffer = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 80])
+                frame_data = base64.b64encode(buffer).decode("utf-8")
 
                 if self.frame_callback:
                     self.frame_callback(frame_data)
 
-                time.sleep(0.033) # 30 fps
+                time.sleep(
+                    self.frame_delay
+                )  # Use calculated frame delay instead of hardcoded value
 
         except Exception as e:
             logger.error(f"Error streaming video: {e}")
@@ -92,10 +119,7 @@ class VideoStream():
         already running.
         """
         if self._video_thread is None or not self._video_thread.is_alive():
-            self._video_thread = threading.Thread(
-                target=self.on_video,
-                daemon=True
-            )
+            self._video_thread = threading.Thread(target=self.on_video, daemon=True)
             self._video_thread.start()
             logger.info("Started video processing thread")
 

--- a/src/omOS_vlm/vila_vlm/__init__.py
+++ b/src/omOS_vlm/vila_vlm/__init__.py
@@ -7,5 +7,6 @@ for real-time video analysis and description generation.
 
 from .vila_processor import VILAProcessor
 from .args import VILAArgParser
+from .__main__ import main
 
-__all__ = ["VILAProcessor", "VILAArgParser"]
+__all__ = ["VILAProcessor", "VILAArgParser", "main"]

--- a/src/omOS_vlm/vila_vlm/__init__.py
+++ b/src/omOS_vlm/vila_vlm/__init__.py
@@ -1,0 +1,11 @@
+"""
+VILA Vision Language Model integration for omOS.
+
+This module provides integration with the VILA (Vision Language) model
+for real-time video analysis and description generation.
+"""
+
+from .vila_processor import VILAProcessor
+from .args import VILAArgParser
+
+__all__ = ["VILAProcessor", "VILAArgParser"]

--- a/src/omOS_vlm/vila_vlm/__main__.py
+++ b/src/omOS_vlm/vila_vlm/__main__.py
@@ -1,0 +1,133 @@
+import logging
+import time
+import threading
+from typing import Optional, Any
+
+from omOS_utils import ws
+from omOS_vlm.video import VideoStream
+from .args import VILAArgParser
+from .vila_processor import VILAProcessor
+
+logger = logging.getLogger(__name__)
+
+
+class Application:
+    """
+    Main application class for standalone VILA VLM processing.
+
+    Coordinates video input/output, WebSocket communication, and VLM processing
+    for the VILA model in standalone mode.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Command-line arguments containing configuration parameters
+    """
+
+    def __init__(self, args):
+        self.args = args
+        self.ws_server: Optional[ws.Server] = None
+        self.vlm_processor: Optional[VILAProcessor] = None
+        self.video_stream: Optional[VideoStream] = None
+        self.running: bool = False
+
+        # Set logging level
+        logging.basicConfig(
+            level=getattr(logging, args.log_level.upper()),
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+        for name in logging.root.manager.loggerDict:
+            logging.getLogger(name).setLevel(getattr(logging, args.log_level.upper()))
+
+    @staticmethod
+    def parse_arguments():
+        """
+        Parse command-line arguments for VILA configuration.
+
+        Returns
+        -------
+        argparse.Namespace
+            Parsed command-line arguments
+        """
+        parser = VILAArgParser()
+        return parser.parse_args()
+
+    def setup_vlm_processing(self):
+        """
+        Configure VLM processing components.
+
+        Sets up VILA processor, WebSocket server, and video streaming.
+        """
+        # Initialize WebSocket server
+        self.ws_server = ws.Server(
+            host=getattr(self.args, "ws_host", "localhost"),
+            port=getattr(self.args, "ws_port", 6789),
+        )
+        self.ws_server.start()
+
+        # Initialize VILA processor
+        self.vlm_processor = VILAProcessor(
+            self.args, self.ws_server.handle_global_response
+        )
+        logger.info(f"VILA VLM initialized with args: {self.args}")
+
+        # Set up video streaming
+        self.video_stream = VideoStream(
+            self.vlm_processor.on_video, fps=getattr(self.args, "fps", 10)
+        )
+        self.video_stream.start()
+
+        # Start VLM processing thread
+        vlm_thread = threading.Thread(
+            target=self.vlm_processor.process_frames,
+            daemon=True,
+        )
+        vlm_thread.start()
+
+    def start(self):
+        """
+        Start the application.
+
+        Initializes and starts all components based on configuration.
+        Handles main application loop and graceful shutdown.
+        """
+        logger.info("Starting VILA VLM application...")
+        self.setup_vlm_processing()
+        self.running = True
+
+        try:
+            while self.running:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            self.stop()
+
+    def stop(self):
+        """
+        Stop the application and cleanup resources.
+
+        Performs graceful shutdown of all components.
+        """
+        logger.info("Shutting down VILA VLM...")
+        self.running = False
+
+        if self.ws_server:
+            self.ws_server.stop()
+
+        if self.vlm_processor:
+            self.vlm_processor.stop()
+
+        if self.video_stream:
+            self.video_stream.stop()
+
+
+def main():
+    """
+    Main entry point for running VILA VLM standalone.
+    """
+    args = Application.parse_arguments()
+    app = Application(args)
+    app.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/omOS_vlm/vila_vlm/args.py
+++ b/src/omOS_vlm/vila_vlm/args.py
@@ -1,0 +1,61 @@
+import argparse
+from typing import List, Optional
+
+
+class VILAArgParser(argparse.ArgumentParser):
+    """
+    Argument parser for VILA VLM configuration.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initialize the VILA argument parser with model-specific options.
+        """
+        super().__init__(
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter, **kwargs
+        )
+
+        # WebSocket connection
+        self.add_argument(
+            "--host",
+            type=str,
+            default="localhost",
+            help="VILA server hostname",
+        )
+        self.add_argument(
+            "--port",
+            type=int,
+            default=8000,
+            help="VILA server WebSocket port",
+        )
+
+        # Video processing
+        self.add_argument(
+            "--frame-skip",
+            type=int,
+            default=5,
+            help="Number of frames to skip between processing",
+        )
+        self.add_argument(
+            "--batch-size",
+            type=int,
+            default=5,
+            help="Number of frames to process in a batch",
+        )
+
+    def parse_args(self, args: Optional[List[str]] = None) -> argparse.Namespace:
+        """
+        Parse command-line arguments.
+
+        Parameters
+        ----------
+        args : Optional[List[str]]
+            List of arguments to parse. If None, uses sys.argv[1:].
+
+        Returns
+        -------
+        argparse.Namespace
+            Parsed arguments
+        """
+        parsed_args = super().parse_args(args)
+        return parsed_args

--- a/src/omOS_vlm/vila_vlm/args.py
+++ b/src/omOS_vlm/vila_vlm/args.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import List, Optional
 
 
 class VILAArgParser(argparse.ArgumentParser):
@@ -7,7 +6,9 @@ class VILAArgParser(argparse.ArgumentParser):
     Argument parser for VILA VLM configuration.
     """
 
-    def __init__(self, **kwargs):
+    Defaults = ["vila", "standalone"]  #: The default options for VILA configuration
+
+    def __init__(self, extras=Defaults, **kwargs):
         """
         Initialize the VILA argument parser with model-specific options.
         """
@@ -15,47 +16,55 @@ class VILAArgParser(argparse.ArgumentParser):
             formatter_class=argparse.ArgumentDefaultsHelpFormatter, **kwargs
         )
 
-        # WebSocket connection
-        self.add_argument(
-            "--host",
-            type=str,
-            default="localhost",
-            help="VILA server hostname",
-        )
-        self.add_argument(
-            "--port",
-            type=int,
-            default=8000,
-            help="VILA server WebSocket port",
-        )
+        # VILA configuration
+        if "vila" in extras:
+            self.add_argument(
+                "--vila-host",
+                type=str,
+                default="localhost",
+                help="VILA server hostname",
+            )
+            self.add_argument(
+                "--vila-port", type=int, default=8000, help="VILA server WebSocket port"
+            )
+            self.add_argument(
+                "--vila-batch-size",
+                type=int,
+                default=5,
+                help="Number of frames to process in a batch",
+            )
 
-        # Video processing
-        self.add_argument(
-            "--frame-skip",
-            type=int,
-            default=5,
-            help="Number of frames to skip between processing",
-        )
-        self.add_argument(
-            "--batch-size",
-            type=int,
-            default=5,
-            help="Number of frames to process in a batch",
-        )
+        # Standalone mode options
+        if "standalone" in extras:
+            self.add_argument(
+                "--log-level",
+                type=str,
+                default="INFO",
+                choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                help="Set the logging level",
+            )
+            self.add_argument(
+                "--ws-host",
+                type=str,
+                default="localhost",
+                help="WebSocket server hostname",
+            )
+            self.add_argument(
+                "--ws-port",
+                type=int,
+                default=8765,
+                help="WebSocket server port",
+            )
+            self.add_argument(
+                "--fps",
+                type=int,
+                default=10,
+                help="Frames per second for video processing",
+            )
 
-    def parse_args(self, args: Optional[List[str]] = None) -> argparse.Namespace:
+    def parse_args(self, **kwargs):
         """
-        Parse command-line arguments.
-
-        Parameters
-        ----------
-        args : Optional[List[str]]
-            List of arguments to parse. If None, uses sys.argv[1:].
-
-        Returns
-        -------
-        argparse.Namespace
-            Parsed arguments
+        Parse command-line arguments with additional configuration.
         """
-        parsed_args = super().parse_args(args)
-        return parsed_args
+        args = super().parse_args(**kwargs)
+        return args

--- a/src/omOS_vlm/vila_vlm/vila_processor.py
+++ b/src/omOS_vlm/vila_vlm/vila_processor.py
@@ -4,6 +4,7 @@ from typing import Optional, Callable, List
 import argparse
 import time
 import threading
+from interfaces.vlm_processor_interface import VLMProcessorInterface
 
 try:
     from omOS_utils.ws.client import Client
@@ -13,7 +14,7 @@ except ModuleNotFoundError:
 logger = logging.getLogger(__name__)
 
 
-class VILAProcessor:
+class VILAProcessor(VLMProcessorInterface):
     """
     VILA Vision Language Model processor for real-time video analysis.
 

--- a/src/omOS_vlm/vila_vlm/vila_processor.py
+++ b/src/omOS_vlm/vila_vlm/vila_processor.py
@@ -1,0 +1,209 @@
+import logging
+import json
+import base64
+from io import BytesIO
+from typing import Optional, Any, Callable, List
+import time
+import argparse
+import numpy as np
+from PIL import Image as PILImage, ImageDraw, ImageFont
+
+try:
+    from omOS_utils.ws.client import Client
+except ModuleNotFoundError:
+    Client = None
+
+logger = logging.getLogger(__name__)
+
+
+class VILAProcessor:
+    """
+    VILA Vision Language Model processor for real-time video analysis.
+
+    Processes video frames through VILA to generate text descriptions
+    of interesting aspects in the video stream. Communicates with a remote
+    VILA server via WebSocket.
+
+    Parameters
+    ----------
+    model_args : argparse.Namespace
+        Command line arguments for model configuration.
+    callback : Optional[Callable[[str], None]], optional
+        Callback function for processing model responses,
+        by default None
+    """
+
+    def __init__(
+        self,
+        model_args: argparse.Namespace,
+        callback: Optional[Callable[[str], None]] = None,
+    ):
+        self.model_args = model_args
+        self.callback = callback
+        self.last_image: Optional[np.ndarray] = None
+        self.num_images: int = 0
+        self.raw_response: str = ""
+        self.response: str = ""
+        self.running: bool = True
+        self.image_buffer: List[str] = []
+
+        # Initialize WebSocket client
+        self.ws_client = Client(f"ws://{model_args.host}:{model_args.port}/ws")
+        self.ws_client.register_message_callback(self._handle_ws_message)
+        self.ws_client.start()
+
+    def _handle_ws_message(self, message: str):
+        """
+        Handle incoming WebSocket messages.
+
+        Parameters
+        ----------
+        message : str
+            The received message in JSON format
+        """
+        try:
+            data = json.loads(message)
+            if "response" in data:
+                self.raw_response = data["response"]
+                self.response = data["response"]  # No cleanup needed for VILA responses
+                logger.info(f"VILA response: {self.response}")
+
+                if self.callback:
+                    self.callback(json.dumps({"vila_reply": self.response}))
+            elif "error" in data:
+                logger.error(f"VILA server error: {data['error']}")
+        except Exception as e:
+            logger.error(f"Error handling WebSocket message: {e}")
+
+    def _numpy_to_base64(self, image: np.ndarray) -> str:
+        """
+        Convert numpy image to base64 string.
+
+        Parameters
+        ----------
+        image : np.ndarray
+            Input image as numpy array
+
+        Returns
+        -------
+        str
+            Base64 encoded image string
+        """
+        # Convert numpy array to PIL Image
+        pil_image = PILImage.fromarray(image)
+
+        # Convert PIL Image to base64
+        buffered = BytesIO()
+        pil_image.save(buffered, format="PNG")
+        return base64.b64encode(buffered.getvalue()).decode()
+
+    def _add_text_overlay(self, image: np.ndarray, text: str) -> np.ndarray:
+        """
+        Add text overlay to image.
+
+        Parameters
+        ----------
+        image : np.ndarray
+            Input image
+        text : str
+            Text to overlay
+
+        Returns
+        -------
+        np.ndarray
+            Image with text overlay
+        """
+        # Convert numpy array to PIL Image for text drawing
+        pil_image = PILImage.fromarray(image)
+        draw = ImageDraw.Draw(pil_image)
+
+        # Add text with background
+        x, y = 5, 5
+        draw.text((x, y), text, fill=(255, 0, 0))
+
+        # Convert back to numpy array
+        return np.array(pil_image)
+
+    def on_video(self, image: np.ndarray) -> np.ndarray:
+        """
+        Process incoming video frames.
+
+        Parameters
+        ----------
+        image : np.ndarray
+            Input video frame as numpy array
+
+        Returns
+        -------
+        np.ndarray
+            Annotated video frame
+        """
+        self.last_image = image.copy()
+
+        annotation = "Accumulating:" + str(self.num_images)
+        if self.num_images >= self.model_args.batch_size:
+            annotation = "VILA:" + self.response
+
+        return self._add_text_overlay(image, annotation)
+
+    async def process_frames(self, video_output: Any, video_source: Any):
+        """
+        Main frame processing loop.
+
+        Parameters
+        ----------
+        video_output : Any
+            Video output stream handler
+        video_source : Any
+            Video input source handler
+        """
+        skip = 0
+        while self.running:
+            if self.last_image is None:
+                continue
+
+            if skip < self.model_args.frame_skip:
+                skip += 1
+                continue
+            else:
+                skip = 0
+
+            # Convert and store image
+            if self.last_image is not None:
+                img_b64 = self._numpy_to_base64(self.last_image)
+                self.image_buffer.append(img_b64)
+                self.last_image = None
+
+            if self.num_images < self.model_args.batch_size:
+                self.num_images += 1
+                continue
+            else:
+                self.num_images = 0
+
+            # Send accumulated images to VILA server
+            try:
+                if self.ws_client.is_connected():
+                    message = {
+                        "images": self.image_buffer,
+                        "prompt": "What is the most interesting aspect in this series of images?",
+                    }
+                    self.ws_client.send_message(json.dumps(message))
+                else:
+                    logger.warning("WebSocket not connected to VILA server")
+            except Exception as e:
+                logger.error(f"Error sending frames to VILA server: {e}")
+
+            # Clear image buffer
+            self.image_buffer = []
+
+            if video_source.eos:
+                video_output.stream.Close()
+                break
+
+    def stop(self):
+        """
+        Stop frame processing and cleanup resources.
+        """
+        self.running = False
+        if self.ws_client:
+            self.ws_client.stop()


### PR DESCRIPTION
Implements basic module logic to use remote VILA vLM model for visual reasoning.

`poetry run python -m omOS_vlm.vila_vlm --vila-host {remote_instance_host} --vila-port {port}`

For now, i wanted to keep it simple and didn't implement video outputting or other advanced configurations.

- Added an fps parameter to video stream to control frame rate
